### PR TITLE
prepare.sh: prepare all prereqs

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -6,10 +6,12 @@ export PYTHONPATH=./ubuntu-image
 
 ./inject-initramfs.sh \
     -o pc-kernel_214.snap \
-    -b mke2fs,grub-editenv \
-    pc-kernel_214-orig.snap core-build/initramfs
+    -b ./e2fsprogs/misc/mke2fs,grub-editenv \
+    pc-kernel_*.snap core-build/initramfs
 
 ubuntu-image/ubuntu-image snap \
-    --snap pc-amd64-gadget/pc_20-0.1_amd64.snap \
-    --snap pc-kernel_214.snap \
+    --snap pc_*.snap \
+    --snap pc-kernel_*.snap \
+    --snap snapd_*.snap \
+    --snap core18_*.snap
     mvo-amd64.signed

--- a/inject-initramfs.sh
+++ b/inject-initramfs.sh
@@ -56,7 +56,7 @@ resquash() {
         done
         output="$kernel.$num"
     fi
-    mksquashfs "$rootdir" "$output" -noappend -comp xz -no-xattrs -no-fragments
+    mksquashfs "$rootdir" "$output" -noappend -comp gzip -no-xattrs -no-fragments
     echo "Created $output"
 }
 

--- a/prepare.sh
+++ b/prepare.sh
@@ -2,6 +2,15 @@
 
 set -e
 
+add_cleanup() {
+    if [ ! -x cleanup.sh ]; then
+        echo '#!/bin/sh' > cleanup.sh
+        echo '# (no set -e on purpose)'  >> cleanup.sh
+        chmod +x cleanup.sh
+    fi
+    echo "$@" >> cleanup.sh
+}
+
 build_mke2fs() {
     git clone https://git.kernel.org/pub/scm/fs/ext2/e2fsprogs.git
     (cd e2fsprogs
@@ -31,12 +40,77 @@ get_ubuntu_core() {
     )
 }
 
+get_ubuntu_image() {
+    REPO="https://github.com/mvo5/ubuntu-image.git"
+    BRANCH="uc20-recovery"
+    
+    git clone -b "$BRANCH" "$REPO"
+}
 
-# Also needed:
-# https://github.com/CanonicalLtd/ubuntu-image/pull/171
-# https://github.com/snapcore/snapd/pull/6899
+add_bind_mount() {
+    SRC="$1"
+    DST="$2"
+    if [ -e "$2" ]; then
+        sudo mount -o bind "$1" "$2"
+        add_cleanup "sudo umount $2"
+    fi
+}
 
+get_snapd_uc20() {
+    REPO="https://github.com/mvo5/snappy.git"
+    BRANCH="prepare-image-with-recovery"
+    
+    GOPATH="$(pwd)/go"
+    DST="$GOPATH/src/github.com/snapcore/snapd"
+    
+    # fake GOPATH
+    export GOPATH
+    mkdir -p "$DST"
+    if [ ! -d "$DST/cmd/snap" ]; then
+        git clone -b "$BRANCH" "$REPO" "$DST"
+    fi
+    (cd "$DST" && ./get-deps.sh)
 
-build_mke2fs
-build_grub_editenv
+    go build -o go/snap github.com/snapcore/snapd/cmd/snap
+
+    # this alters the system state :/
+    # use "./cleanup.sh" to restore things
+    for m in /snap/core/current/usr/bin/snap /snap/snapd/current/usr/bin/snap /usr/bin/snap; do
+        add_bind_mount "./go/snap" "$m"
+    done
+}
+
+if [ ! -d ./ubuntu-image ]; then
+    get_ubuntu_image
+fi
+
+if [ ! -d ./core-build ]; then
+    REPO="https://github.com/cmatsuoka/core-build.git"
+    BRANCH="install-script"
+    
+    git clone -b "$BRANCH" "$REPO"
+fi
+
+# FIXME: once we put snapd in channel=20 this is no longer needed
+#        we can just use the "snapd" snap from channel=20
+if [ ! -x ./go/src/github.com/snapcore/snapd/cmd/snap/snap ]; then
+    get_snapd_uc20
+fi
+
+if [ ! -e mvo-amd64.signed ]; then
+    wget https://people.canonical.com/~mvo/tmp/mvo-amd64.signed
+fi
+
+# get the snaps
+snap download --channel=18 pc-kernel
+snap download snapd    # --channel=20 (once available)
+snap download core18   # core20 (once available)
+snap download --channel=20/edge pc
+
+if [ ! -d e2fsprogs ]; then
+    build_mke2fs
+fi
+if [ ! -d grub ]; then
+    build_grub_editenv
+fi
 #get_ubuntu_core 171


### PR DESCRIPTION
This enhances the prepare.sh script to download all the prereqs
to buid a UC20 image.

The idea is that you can do a fresh checkout and run:
- ./prepare.sh
- ./build-image

and things just work. git clean -xfd to cleanup.