### PR TITLE
Fix image building

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -5,13 +5,17 @@ set -e
 export PYTHONPATH=./ubuntu-image
 
 ./inject-initramfs.sh \
-    -o pc-kernel_214.snap \
-    -b ./e2fsprogs/misc/mke2fs,grub-editenv \
+    -o pc-kernel_*.snap \
+    -b ./e2fsprogs/misc/mke2fs,grub/grub-editenv \
     pc-kernel_*.snap core-build/initramfs
 
 ubuntu-image/ubuntu-image snap \
+    --image-size 4G \
     --snap pc_*.snap \
     --snap pc-kernel_*.snap \
     --snap snapd_*.snap \
-    --snap core18_*.snap
+    --snap core18_*.snap \
     mvo-amd64.signed
+
+echo "Run something like (note that the OVMF from 18.04+ does not work)"
+echo "kvm -m 2000 -bios /usr/share/qemu/OVMF.fd pc.img"

--- a/inject-initramfs.sh
+++ b/inject-initramfs.sh
@@ -9,6 +9,7 @@
 
 source /usr/share/initramfs-tools/hook-functions
 
+set -e
 
 unsquash() {
     echo "Unsquashing $kernel..."


### PR DESCRIPTION
This contains some tweaks to fix building the image. With that it should now be possible to do a fresh clone of this repo and run:
```
./prepare.sh
./build-image.sh
```
and have a booting image. It still fails in seeding but that is a issue in `snap prepare-image` where it renames the kernel to "kernel.snap" but does not adjust the seed.yaml file.