### PR TITLE
build-image.sh: make "/var/lib/snapd/seed" available inside core18 as…

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -13,6 +13,7 @@ sudo ./inject-snap.sh \
     -o core18_*.snap \
     -f usr/share/subiquity:console-conf-wrapper \
     -f bin:chooser/chooser \
+    -d var/lib/snapd/seed \
     core18_*.snap
 
 ./inject-snap.sh \

--- a/inject-snap.sh
+++ b/inject-snap.sh
@@ -29,6 +29,17 @@ add_files() {
     fi
 }
 
+add_dirs() {
+    if [ "${#dirs[@]}" -gt 0 ]; then
+        for item in ${dirs[@]}; do
+            destdir=${item}
+            echo "Making $destdir"
+            mkdir -p "$rootdir/$destdir"
+        done
+    fi
+}
+
+
 resquash() {
     if [ -z "$output" ]; then
         num=1
@@ -51,13 +62,16 @@ tmpdir=$(mktemp -d -t inject-XXXXXXXXXX)
 rootdir="$tmpdir/root"
 files=()
 
-while getopts "ho:f:" opt; do
+while getopts "ho:f:d:" opt; do
     case "${opt}" in
         o)
             output="$OPTARG"
             ;;
         f)
             files+=("$OPTARG")
+            ;;
+        d)
+            dirs+=("$OPTARG")
             ;;
         *)
             usage
@@ -80,5 +94,6 @@ trap finish EXIT
 
 unsquash
 add_files
+add_dirs
 resquash
 


### PR DESCRIPTION
… mount point for recovery-system

This makes bind mounting recovery systems possible.