### PR TITLE
build-image.sh: use core20 instead of core18

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -10,11 +10,11 @@ export PYTHONPATH=./ubuntu-image
     pc-kernel_*.snap core-build/initramfs
 
 sudo ./inject-snap.sh \
-    -o core18_*.snap \
+    -o core20_*.snap \
     -f usr/share/subiquity:console-conf-wrapper \
     -f bin:chooser/chooser \
     -d var/lib/snapd/seed \
-    core18_*.snap
+    core20_*.snap
 
 ./inject-snap.sh \
     -o snapd_*.snap \
@@ -27,8 +27,8 @@ ubuntu-image/ubuntu-image snap \
     --snap pc_*.snap \
     --snap pc-kernel_*.snap \
     --snap snapd_*.snap \
-    --snap core18_*.snap \
-    mvo-amd64.signed
+    --snap core20_*.snap \
+    core20-mvo-amd64.model
 
 echo "Run something like (note that the OVMF from 18.04+ does not work)"
 echo "kvm -m 2000 -bios /usr/share/qemu/OVMF.fd pc.img"

--- a/inject-snap.sh
+++ b/inject-snap.sh
@@ -3,7 +3,7 @@
 # Use this script to inject stuff into an existing snap.
 #
 # Example:
-# $ ./inject-snap -o core18.snap -d bin mke2fs ../core18_970.snap
+# $ ./inject-snap -o core20.snap -d bin mke2fs ../core20_970.snap
 
 
 source /usr/share/initramfs-tools/hook-functions

--- a/prepare.sh
+++ b/prepare.sh
@@ -97,14 +97,14 @@ if [ ! -x ./go/snap ]; then
     get_snapd_uc20
 fi
 
-if [ ! -e mvo-amd64.signed ]; then
-    wget https://people.canonical.com/~mvo/tmp/mvo-amd64.signed
+if [ ! -e core20-mvo-amd64.model ]; then
+    wget https://people.canonical.com/~mvo/tmp/core20-mvo-amd64.model
 fi
 
 # get the snaps
 snap download --channel=18 pc-kernel
 snap download snapd  --channel=edge/experimental-uc20
-snap download core18   # core20 (once available)
+snap download core20 --edge
 snap download --channel=20/edge pc
 
 if [ ! -d grub ]; then


### PR DESCRIPTION
Needs to land in sync with:
https://github.com/cmatsuoka/core-build/compare/writable-ramdisk...mvo5:20?expand=1
https://github.com/cmatsuoka/snapd/compare/writable-ramdisk...mvo5:writable-ramdisk?expand=1